### PR TITLE
Adding NoProtect middleware for testing purpose

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -1,6 +1,7 @@
 package nosurfctx
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 )
@@ -21,6 +22,14 @@ var DefaultErrorHandler = defaultErrorHandler
 // attacks, taking into account the exempt HTTP methods.
 func Protect(h http.HandlerFunc) http.HandlerFunc {
 	return protect(h, true)
+}
+
+// Add middleware to bypass CSRF protection for testing purpose
+func NoProtect(h http.HandlerFunc) http.HandlerFunc {
+  return func(w http.ResponseWriter, r *http.Request) {
+    r = r.WithContext(context.WithValue(r.Context(), csrfKey, "DUMMY"))
+    h(w, r)
+  }
 }
 
 // ForceProtect is middleware used for potecting routes from CSRF attacks,


### PR DESCRIPTION
I added NoProtect middleware so that it's easier for user to test Golang controllers / handlers.

Here's a sample usage for testing purpose:
https://gist.github.com/aprimadi/cbd1377c16cba025a777be59361cefdc